### PR TITLE
Fixed master hostname YAML template

### DIFF
--- a/Guides/UPI/baremetal/node-hostname-resolution.md
+++ b/Guides/UPI/baremetal/node-hostname-resolution.md
@@ -29,8 +29,8 @@ apiVersion: machineconfiguration.openshift.io/v1
 kind: MachineConfig
 metadata:
   labels:
-    machineconfiguration.openshift.io/role: worker
-  name: okd-configure-worker-node-hostname
+    machineconfiguration.openshift.io/role: master
+  name: okd-configure-master-node-hostname
 spec:
   config:
     ignition:


### PR DESCRIPTION
As it was referring to workers instead of masters - copying it didn't set up the hostname-fixing service on master nodes as desired.